### PR TITLE
236. Lowest Common Ancestor of a Binary Tree

### DIFF
--- a/LEETCODE
+++ b/LEETCODE
@@ -1,0 +1,32 @@
+class Solution:
+    def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
+        stack=[]
+        parent=defaultdict(TreeNode)
+        res=[]
+        stack.append([root,0])
+        while(stack):
+            t=stack.pop()
+            node=t[0]
+            level=t[1]
+            if node.val in [p.val,q.val]:
+                res.append([node,level])
+            if node.right:
+                stack.append([node.right,level+1])
+                parent[node.right]=node
+            if node.left:
+                stack.append([node.left,level+1])
+                parent[node.left]=node
+        p,pl=res[0][0],res[0][1]
+        q,ql=res[1][0],res[1][1]
+        if pl>ql:
+            for i in range(pl-ql):
+                p=parent[p]
+                print(p.val)
+        elif pl<ql:
+            for i in range(ql-pl):
+                q=parent[q]
+                print(q.val)
+        while(p.val!=q.val):
+            p=parent[p]
+            q=parent[q]
+        return p


### PR DESCRIPTION
class Solution:
    def lowestCommonAncestor(self, root: 'TreeNode', p: 'TreeNode', q: 'TreeNode') -> 'TreeNode':
        stack=[]
        parent=defaultdict(TreeNode)
        res=[]
        stack.append([root,0])
        while(stack):
            t=stack.pop()
            node=t[0]
            level=t[1]
            if node.val in [p.val,q.val]:
                res.append([node,level])
            if node.right:
                stack.append([node.right,level+1])
                parent[node.right]=node
            if node.left:
                stack.append([node.left,level+1])
                parent[node.left]=node
        p,pl=res[0][0],res[0][1]
        q,ql=res[1][0],res[1][1]
        if pl>ql:
            for i in range(pl-ql):
                p=parent[p]
                print(p.val)
        elif pl<ql:
            for i in range(ql-pl):
                q=parent[q]
                print(q.val)
        while(p.val!=q.val):
            p=parent[p]
            q=parent[q]
        return p